### PR TITLE
Upload and display profile image with firebase

### DIFF
--- a/lib/screens/register_page.dart
+++ b/lib/screens/register_page.dart
@@ -1,8 +1,6 @@
-
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:get/get_utils/src/get_utils/get_utils.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
 import 'package:SharChat/services/auth/auth_services.dart';
@@ -25,8 +23,6 @@ class _RegisterPageState extends State<RegisterPage> {
   final nameController=TextEditingController();
   final passwordController=TextEditingController();
   final confirmPasswordController=TextEditingController();
-  String imagePath = ''; // Define imagePath
-  String uid = ''; // Define uid
   XFile?imageFile;
 bool aShow=true;
 bool emailShow=false;
@@ -55,7 +51,10 @@ if(passwordController.text!=confirmPasswordController.text){
   final authService=Provider.of<AuthServices>(context,listen: false);
 try{
   await authService.signUpWithEmailAndPassword(emailController.text, passwordController.text,nameController.text);
-  await authService.uploadImage(imagePath, uid);
+  if (imageFile != null) {
+    final String currentUid = FirebaseAuth.instance.currentUser!.uid;
+    await authService.uploadImage(imageFile!.path, currentUid);
+  }
 }catch(e){
   ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(e.toString())));
 


### PR DESCRIPTION
Implement Firebase image upload and display for user profiles.

Users can now select a profile image during registration, which is uploaded to Firebase Storage and its URL saved to Firestore. The profile image is then displayed in the drawer on the home page, and users can update it by tapping the avatar.

---
<a href="https://cursor.com/background-agent?bcId=bc-2838b481-79e7-44ec-9391-30e3ff6644a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2838b481-79e7-44ec-9391-30e3ff6644a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

